### PR TITLE
Fixes Angular compile error and a few typing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The nativescript BarcodeView is base on [nativescript-barcodescanner](https://gi
 (https://github.com/EddyVerbruggen)
 ## Plain NativeScript
 
-<span style="color:red">IMPORTANT: </span>_Make sure you include `xmlns:mdc="nativescript-canvas"` on the Page element_
+<span style="color:red">IMPORTANT: </span>_Make sure you include `xmlns:bc="nativescript-barcodeview"` on the Page element_
 
 ### XML
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ registerElement('BarcodeView', () => BarcodeView);
 ```
 
 ```html
-<BarcodeView width="100" height="100" (scanResult)="onScanResult($event)"></CanvasView>
+<BarcodeView width="100" height="100" (scanResult)="onScanResult($event)"></BarcodeView>
 ```
 
 ## NativeScript + Vue

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # NativeScript BarcodeView
 
-[npm-image]:http://img.shields.io/npm/v/nativescript-barcodeview.svg
-[npm-url]:https://npmjs.org/package/nativescript-barcodeview
-[downloads-image]:http://img.shields.io/npm/dm/nativescript-barcodeview.svg
+[npm-image]:http://img.shields.io/npm/v/@nativescript-community/ui-barcodeview.svg
+[npm-url]:https://npmjs.org/package/@nativescript-community/ui-barcodeview
+[downloads-image]:http://img.shields.io/npm/dm/@nativescript-community/ui-barcodeview.svg
 
 ## Supported barcode types
 
@@ -32,11 +32,11 @@
 ### A note about `UPC_A` and `EAN_13`
 When either (or both) of these are specified, both can be returned.
 You can check the actual type by inspecting the `format` property of the result object.
-For details, see [#176](https://github.com/EddyVerbruggen/nativescript-barcodeview/issues/176).
+For details, see [#176](https://github.com/EddyVerbruggen/nativescript-barcodescanner/issues/176).
 
 ## Installation
 
-* `tns plugin add nativescript-barcodeview`
+* `tns plugin add @nativescript-community/ui-barcodeview`
 
 Be sure to run a new build after adding plugins to avoid any issues.
 
@@ -49,12 +49,12 @@ The nativescript BarcodeView is base on [nativescript-barcodescanner](https://gi
 (https://github.com/EddyVerbruggen)
 ## Plain NativeScript
 
-<span style="color:red">IMPORTANT: </span>_Make sure you include `xmlns:bc="nativescript-barcodeview"` on the Page element_
+<span style="color:red">IMPORTANT: </span>_Make sure you include `xmlns:mdc="@nativescript-community/ui-barcodeview"` on the Page element_
 
 ### XML
 
 ```XML
-<Page xmlns:bc="nativescript-barcodeview">
+<Page xmlns:bc="@nativescript-community/ui-barcodeview">
     <StackLayout horizontalAlignment="center">
         <bc:BarcodeView width="100" height="100" scanResult="onScanResult"/>
    </StackLayout>
@@ -65,7 +65,7 @@ The nativescript BarcodeView is base on [nativescript-barcodescanner](https://gi
 
 ```typescript
 import { registerElement } from 'nativescript-angular/element-registry';
-import { BarcodeView } from 'nativescript-barcodeview';
+import { BarcodeView } from '@nativescript-community/ui-barcodeview';
 registerElement('BarcodeView', () => BarcodeView);
 ```
 
@@ -77,7 +77,7 @@ registerElement('BarcodeView', () => BarcodeView);
 
 ```javascript
 import Vue from 'nativescript-vue';
-(<any>Vue).registerElement('BarcodeView', () => require('nativescript-barcodeview').BarcodeView);
+(<any>Vue).registerElement('BarcodeView', () => require('@nativescript-community/ui-barcodeview').BarcodeView);
 
 ```
 

--- a/src/barcodeview-common.ts
+++ b/src/barcodeview-common.ts
@@ -73,9 +73,9 @@ export class BarcodeView extends ContentView {
     protected pause: boolean;
     protected torchOn: boolean;
 
-    abstract pauseScanning();
+    pauseScanning();
 
-    abstract resumeScanning();
+    resumeScanning();
 }
 
 export function generateBarCode(options: { text: string; type: BarcodeFormat; width: number; height: number; frontColor?: Color | string; backColor?: Color | string }): ImageSource {

--- a/src/barcodeview-common.ts
+++ b/src/barcodeview-common.ts
@@ -63,7 +63,7 @@ export const pauseProperty = new Property<BarcodeView, boolean>({
     valueConverter: booleanConverter
 });
 
-export abstract class BarcodeView extends ContentView {
+export class BarcodeView extends ContentView {
     static scanResultEvent: string = 'scanResult';
 
     protected formats: string;

--- a/src/barcodeview.android.ts
+++ b/src/barcodeview.android.ts
@@ -82,13 +82,6 @@ export class BarcodeView extends BarcodeScannerBaseView {
         return new com.journeyapps.barcodescanner.BarcodeView(this._context);
     }
 
-    onActivityResume() {
-        this.nativeViewProtected.resume();
-    }
-
-    onActivityPause() {
-        this.nativeViewProtected.pause();
-    }
     initNativeView() {
         super.initNativeView();
         const barcodeView = this.nativeViewProtected;
@@ -118,8 +111,8 @@ export class BarcodeView extends BarcodeScannerBaseView {
             possibleResultPoints(param0: java.util.List<com.google.zxing.ResultPoint>) {}
         });
         barcodeView.decodeContinuous(this.callback);
-        androidApp.on('activityResumed', this.onActivityResume, this);
-        androidApp.on('activityPaused', this.onActivityPause, this);
+        androidApp.on('activityResumed', this.resumeScanning, this);
+        androidApp.on('activityPaused', this.pauseScanning, this);
         if (!this.formats) {
             const types = getBarcodeTypes(null);
             barcodeView.setDecoderFactory(new com.journeyapps.barcodescanner.DefaultDecoderFactory(types));
@@ -137,8 +130,8 @@ export class BarcodeView extends BarcodeScannerBaseView {
         this.callback = null;
         // this.beepManager = null;
 
-        androidApp.off('activityResumed', this.onActivityResume, this);
-        androidApp.off('activityPaused', this.onActivityPause, this);
+        androidApp.off('activityResumed', this.resumeScanning, this);
+        androidApp.off('activityPaused', this.pauseScanning, this);
         super.disposeNativeView();
     }
 

--- a/src/barcodeview.android.ts
+++ b/src/barcodeview.android.ts
@@ -118,8 +118,8 @@ export class BarcodeView extends BarcodeScannerBaseView {
             possibleResultPoints(param0: java.util.List<com.google.zxing.ResultPoint>) {}
         });
         barcodeView.decodeContinuous(this.callback);
-        androidApp.on('onActivityResumed', this.onActivityResume, this);
-        androidApp.on('onActivityPaused', this.onActivityPause, this);
+        androidApp.on('activityResumed', this.onActivityResume, this);
+        androidApp.on('activityPaused', this.onActivityPause, this);
         if (!this.formats) {
             const types = getBarcodeTypes(null);
             barcodeView.setDecoderFactory(new com.journeyapps.barcodescanner.DefaultDecoderFactory(types));
@@ -137,8 +137,8 @@ export class BarcodeView extends BarcodeScannerBaseView {
         this.callback = null;
         // this.beepManager = null;
 
-        androidApp.off('onActivityResumed', this.onActivityResume, this);
-        androidApp.off('onActivityPaused', this.onActivityPause, this);
+        androidApp.off('activityResumed', this.onActivityResume, this);
+        androidApp.off('activityPaused', this.onActivityPause, this);
         super.disposeNativeView();
     }
 

--- a/src/barcodeview.ios.ts
+++ b/src/barcodeview.ios.ts
@@ -6,6 +6,8 @@ import { Color } from '@nativescript/core/color';
 export class BarcodeView extends BarcodeScannerBaseView {
     private _reader: QRCodeReader;
     private _hasSupport;
+    private _player: AVAudioPlayer;
+    private lastText: string;
 
     constructor() {
         super();
@@ -28,14 +30,12 @@ export class BarcodeView extends BarcodeScannerBaseView {
     }
 
     disposeNativeView() {
+        this.pauseScanning();
         this._reader = null;
         this._player = null;
         this.lastText = null;
-        // this._scanner.delegate = null;
-        // this._scanner = null;
+        super.disposeNativeView();
     }
-    private _player: AVAudioPlayer;
-    private lastText: string;
 
     initNativeView() {
         super.initNativeView();


### PR DESCRIPTION
- An instance of an `abstract` class cannot be created in `registerElement('BarcodeView', () => BarcodeView);`
- Android event name correction
- Properly dispose the view on iOS