### PR TITLE
Add module.modulemap file for Objective-C code.

### DIFF
--- a/plugin/platforms/ios/src/module.modulemap
+++ b/plugin/platforms/ios/src/module.modulemap
@@ -1,0 +1,5 @@
+module LibraryName {
+    umbrella header "QRCodeReader.h"
+    export *
+    module * { export * }
+}


### PR DESCRIPTION
During a `ns run ios` this message would appear:
```
warning: Directory /Users/adnan/play/tyltgo/packages/courier-app/node_modules/@nativescript-community/ui-bar
codeview/platforms/ios/src with native iOS source code doesn't contain a modulemap file. Metadata for it will not be generated and it will not be accessible from JavaScript. To learn more see https://docs.nativescript.org/guides/ios-source-code
```

And in iOS, during runtime it showed this error:
```
Uncaught ReferenceError: QRCodeReader is not defined
```

This commit fixes the compile and runtime issue.